### PR TITLE
fix: show tags only when user starts typing

### DIFF
--- a/components/StickyNoteInput.tsx
+++ b/components/StickyNoteInput.tsx
@@ -237,17 +237,21 @@ export default function StickyNoteInput({
     }
   }, [feedback]);
 
+  // 포커스 해제 시 태그 메뉴 닫기
   useEffect(() => {
-    if ((!isFocused && !isTagMenuOpen) || isClassifying) {
+    if (!isFocused && isTagMenuOpen) {
       setIsTagMenuOpen(false);
     }
-  }, [isFocused, isTagMenuOpen, isClassifying]);
+  }, [isFocused, isTagMenuOpen]);
 
+  // 태그 UI는 실제 타이핑(content 있음)할 때만 표시
   useEffect(() => {
     let showTimer: ReturnType<typeof setTimeout> | null = null;
     let hideTimer: ReturnType<typeof setTimeout> | null = null;
 
-    if (isActiveInput) {
+    const shouldShowTag = content.length > 0 && !isClassifying;
+
+    if (shouldShowTag) {
       setIsTagUiMounted(true);
       showTimer = setTimeout(() => {
         setIsTagUiVisible(true);
@@ -263,7 +267,7 @@ export default function StickyNoteInput({
       if (showTimer) clearTimeout(showTimer);
       if (hideTimer) clearTimeout(hideTimer);
     };
-  }, [isActiveInput]);
+  }, [content, isClassifying]);
 
 
 
@@ -556,7 +560,7 @@ export default function StickyNoteInput({
         disabled={isClassifying}
       />
       
-      {/* 중앙 하단 태그 드롭다운 (포스트잇 확장 완료 후 페이드 인) */}
+      {/* 중앙 하단 태그 드롭다운 (입력 시작 후에만 표시) */}
       {isTagUiMounted && (
         <div
           ref={tagMenuRef}
@@ -568,9 +572,9 @@ export default function StickyNoteInput({
         >
           <button
             type="button"
-            disabled={isClassifying}
+            disabled={isClassifying || !isTagUiVisible}
             onClick={() => setIsTagMenuOpen((prev) => !prev)}
-            className={`inline-flex items-center gap-2 rounded-full border border-black/10 px-3 py-1.5 text-sm font-bold transition hover:opacity-90 ${categoryUI[resolvedCategory].bg} ${categoryUI[resolvedCategory].text} ${isClassifying ? 'cursor-not-allowed opacity-60' : ''}`}
+            className={`inline-flex items-center gap-2 rounded-full border border-black/10 px-3 py-1.5 text-sm font-bold transition hover:opacity-90 ${categoryUI[resolvedCategory].bg} ${categoryUI[resolvedCategory].text} ${isClassifying || !isTagUiVisible ? 'cursor-not-allowed opacity-60' : ''}`}
             title="태그 선택"
           >
             {(() => {


### PR DESCRIPTION
Tags should appear after content is entered, not on initial memo click.

- Uses content.length > 0 trigger instead of focus state
- Tested locally and verified working behavior
- Follows Notion pattern: apply tags while typing