### PR TITLE
fix: pin Astryx runtime-compatible release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "new_projects",
       "version": "0.1.0",
       "dependencies": {
-        "@astryxdesign/core": "^0.1.5",
+        "@astryxdesign/core": "0.1.4",
         "@notionhq/client": "^5.9.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-toast": "^1.2.15",
-        "@stylexjs/stylex": "^0.19.0",
+        "@stylexjs/stylex": "0.18.3",
         "@supabase/supabase-js": "^2.56.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -113,12 +113,12 @@
       "license": "MIT"
     },
     "node_modules/@astryxdesign/core": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@astryxdesign/core/-/core-0.1.5.tgz",
-      "integrity": "sha512-5z9KcFSWoTyAiAHyuSwcLr5J8898vcX0Rei5F1fUwgBfMmxP87A1hHbj33uge5f0k0Tq8AiywhvZTzANdeQthw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@astryxdesign/core/-/core-0.1.4.tgz",
+      "integrity": "sha512-pLwdh8Pu4ifgQ3thiaFjzitWzVpGJmyaSgNe2AZnGwGO1E876HY4k7s6m2wDnxbt5kxdSSeu0O6axq1LxUbwEQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@stylexjs/stylex": "^0.19.0",
+        "@stylexjs/stylex": "^0.18.3",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0"
       }
@@ -2225,9 +2225,9 @@
       "license": "MIT"
     },
     "node_modules/@stylexjs/stylex": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.19.0.tgz",
-      "integrity": "sha512-CnUFp7YMaDLDeemsWOfJgoC/gKM5P/yBNMcpJaE6ChJmXr7s0DJwSeGTTlHJcqqwN9OW1qGtmARWLFhGZN1pTA==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.18.3.tgz",
+      "integrity": "sha512-15gDzAJAorOE0yzxaWLNxldW2aqdmCiLG5QcPD8nmVCVqvrWp0Asgv45zk7LtN86WJb/4Ym9eQ6qT5MJW59tWQ==",
       "license": "MIT",
       "dependencies": {
         "css-mediaquery": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "notion:upload-prd": "node scripts/notion-upload-prd.mjs"
   },
   "dependencies": {
-    "@astryxdesign/core": "^0.1.5",
+    "@astryxdesign/core": "0.1.4",
     "@notionhq/client": "^5.9.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-toast": "^1.2.15",
-    "@stylexjs/stylex": "^0.19.0",
+    "@stylexjs/stylex": "0.18.3",
     "@supabase/supabase-js": "^2.56.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Root cause
`@astryxdesign/core` 0.1.5 ships production bundles compiled against `react/jsx-dev-runtime` (`jsxDEV`). In Next.js production mobile rendering, that runtime export is unavailable, causing `TypeError: jsxDEV is not a function` and a client-side crash.

## Fix
- Pin `@astryxdesign/core` to 0.1.4, whose production bundle uses `react/jsx-runtime`.
- Pin its compatible `@stylexjs/stylex` peer version 0.18.3.

## Verification
- Reproduced the production crash with a Playwright Android-sized viewport before the change.
- After the pin, a production `next start` mobile smoke test rendered the memo feed with no page errors.
- `npm run build`, `npm run lint` (0 errors), and `npx vitest run` (4/4) pass.